### PR TITLE
Added missing parts for the comparison of STA objects

### DIFF
--- a/frost_sta_client/model/datastream.py
+++ b/frost_sta_client/model/datastream.py
@@ -313,7 +313,7 @@ class Datastream(entity.Entity):
         self.name = state.get("name", None)
         self.description = state.get("description", None)
         self.observation_type = state.get("observationType", None)
-        self.properties = state.get("properties", None)
+        self.properties = state.get("properties", {})
         if state.get("unitOfMeasurement", None) is not None:
             self.unit_of_measurement = frost_sta_client.model.ext.unitofmeasurement.UnitOfMeasurement()
             self.unit_of_measurement.__setstate__(state["unitOfMeasurement"])

--- a/frost_sta_client/model/ext/unitofmeasurement.py
+++ b/frost_sta_client/model/ext/unitofmeasurement.py
@@ -68,3 +68,16 @@ class UnitOfMeasurement:
         self.symbol = state.get("symbol", None)
         self.definition = state.get("definition", None)
         self.name = state.get("name", None)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+        if not isinstance(other, type(self)):
+            return False
+        if self.name != other.name:
+            return False
+        if self.definition != other.definition:
+            return False
+        if self.symbol != other.symbol:
+            return False
+        return True

--- a/frost_sta_client/model/feature_of_interest.py
+++ b/frost_sta_client/model/feature_of_interest.py
@@ -190,7 +190,7 @@ class FeatureOfInterest(entity.Entity):
         super().__setstate__(state)
         self.name = state.get("name", None)
         self.description = state.get("description", None)
-        self.properties = state.get("properties", None)
+        self.properties = state.get("properties", {})
         self.encoding_type = state.get("encodingType", None)
         self.feature = state.get("feature", None)
         if state.get("Observations", None) is not None and isinstance(state["Observations"], list):

--- a/frost_sta_client/model/location.py
+++ b/frost_sta_client/model/location.py
@@ -199,6 +199,10 @@ class Location(entity.Entity):
             return False
         if self.encoding_type != other.encoding_type:
             return False
+        if self.location != other.location:
+            return False
+        if self.properties != other.properties:
+            return False
         return True
 
     def __ne__(self, other):
@@ -227,7 +231,7 @@ class Location(entity.Entity):
         self.name = state.get("name", None)
         self.description = state.get("description", None)
         self.encoding_type = state.get("encodingType", None)
-        self.properties = state.get("properties", None)
+        self.properties = state.get("properties", {})
         if state.get("Things", None) is not None:
             entity_class = entity_type.EntityTypes['Thing']['class']
             self.things = utils.transform_json_to_entity_list(state['Things'], entity_class)

--- a/frost_sta_client/model/observedproperty.py
+++ b/frost_sta_client/model/observedproperty.py
@@ -198,7 +198,7 @@ class ObservedProperty(entity.Entity):
         self.name = state.get("name", None)
         self.description = state.get("description", None)
         self.definition = state.get("definition", None)
-        self.properties = state.get("properties", None)
+        self.properties = state.get("properties", {})
         if state.get("Datastreams", None) is not None and isinstance(state["Datastreams"], list):
             entity_class = entity_type.EntityTypes['Datastream']['class']
             self.datastreams = utils.transform_json_to_entity_list(state['Datastreams'], entity_class)

--- a/frost_sta_client/model/thing.py
+++ b/frost_sta_client/model/thing.py
@@ -266,7 +266,7 @@ class Thing(entity.Entity):
         super().__setstate__(state)
         self.name = state.get("name", None)
         self.description = state.get("description", None)
-        self.properties = state.get("properties", None)
+        self.properties = state.get("properties", {})
 
         if state.get("Locations", None) is not None and isinstance(state["Locations"], list):
             entity_class = entity_type.EntityTypes['Location']['class']


### PR DESCRIPTION
I have noticed some problems that arise, if two objects are compared and fixed them.

- Creating new objects with empty properties, create an empty dictionary but objects from the server have None, even if they are contentwise the same they failed to be recognized. 
- Datastreams compared unitOfMeasurements, but they could not be compared and failed every time
- Location did not compare its properties and the location itself