### PR TITLE
Compare IDs only if exist

### DIFF
--- a/frost_sta_client/model/entity.py
+++ b/frost_sta_client/model/entity.py
@@ -109,8 +109,9 @@ class Entity(ABC):
             return False
         if id(self) == id(other):
             return True
-        if self.id != other.id:
-            return False
+        if self.id and other.id:
+            if self.id != other.id:
+                return False
         return True
 
     def __ne__(self, other):


### PR DESCRIPTION
Suggestion for https://github.com/FraunhoferIOSB/FROST-Python-Client/issues/24

IDs should not be compared if only one object has one.