### PR TITLE
Allow for adding query parameters in dict (instead of method chaining)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ dist
 **.egg-info/
 
 pyproject.toml
+
+.vscode
+Pipfile*
+*.ipynb

--- a/frost_sta_client/dao/base.py
+++ b/frost_sta_client/dao/base.py
@@ -22,6 +22,7 @@ import requests
 import jsonpatch
 import json
 from furl import furl
+from typing import Dict
 
 
 class BaseDao:
@@ -204,6 +205,6 @@ class BaseDao:
             return "{}({})".format(self.entitytype_plural, id)
         return "{}('{}')".format(self.entitytype_plural, id)
 
-    def query(self):
+    def query(self, params: Dict[str, str] = {}):
         return frost_sta_client.query.query.Query(self.service, self.entitytype, self.entitytype_plural,
-                                                  self.entity_class, self.parent)
+                                                  self.entity_class, self.parent, params)

--- a/frost_sta_client/query/query.py
+++ b/frost_sta_client/query/query.py
@@ -21,15 +21,16 @@ import frost_sta_client.model.ext.entity_list
 import logging
 import requests
 from requests.exceptions import JSONDecodeError
+from typing import Dict
 
 
 class Query:
-    def __init__(self, service, entity, entitytype_plural, entity_class, parent):
+    def __init__(self, service, entity, entitytype_plural, entity_class, parent, params: Dict[str, str] = {}):
         self.service = service
         self.entity = entity
         self.entitytype_plural = entitytype_plural
         self.entity_class = entity_class
-        self.params = {}
+        self.params = params
         self.parent = parent
 
     @property

--- a/frost_sta_client/query/query.py
+++ b/frost_sta_client/query/query.py
@@ -30,7 +30,7 @@ class Query:
         self.entity = entity
         self.entitytype_plural = entitytype_plural
         self.entity_class = entity_class
-        self.params = params
+        self.params = self.assert_params_keys_format(params)
         self.parent = parent
 
     @property
@@ -86,6 +86,16 @@ class Query:
     @parent.setter
     def parent(self, value):
         self._parent = value
+
+    @staticmethod
+    def assert_params_keys_format(params: Dict[str, str]) -> Dict[str, str]:
+        params_out = params.copy()
+        keys_to_assert = ['count', 'top', 'skip', 'select', 'filter', 'orderby', 'expand']
+        for k, v in params.items():
+            if k in keys_to_assert:
+                params_out["$" + k] = v
+                params_out.pop(k)
+        return params_out
 
     def remove_all_params(self, key):
         self.params.pop(key, None)


### PR DESCRIPTION
The proposed changes add functionality to query a FROST server using a dictionary of parameters. To allow for flexible use of parameters. 

Example, query the name of a specific thing.
Now:
```python
service.things().query().filter('id eq 1').select("name").list()
```
Proposed expansion (keeping the existing functionality)
```python
service.things().query({'$filter': 'id eq 1', '$select': 'name'}).list()
# or
service.things().query({'filter': 'id eq 1', 'select': 'name'}).list()
```